### PR TITLE
Add links to Flex and Bison to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ in the `test` subdirectory.
 ## Building libgraphqlparser
 
 libgraphqlparser is built with [CMake](http://www.cmake.org/). If a
-sufficiently-recent version of Flex and Bison are installed on your
+sufficiently-recent version of [Flex](http://flex.sourceforge.net/) and [Bison](http://www.gnu.org/software/bison/) are installed on your
 system, it will use them; otherwise, it will rely on the checked-in
 `parser.tab.{c,h}pp` and `lexer.{h,cpp}`.
 


### PR DESCRIPTION
Crazy small change, while working with this repo I shared it with a couple of people and they had trouble finding info about Flex and Bison, so thought this might as well be added to make things a little easier.