### PR TITLE
Downgrade to cmake 2.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,6 @@ before_install:
   # Versions of g++ prior to 4.8 don't have very good C++11 support.
   - sudo apt-get install -y g++-4.8
     && sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 90
-  - wget http://www.cmake.org/files/v3.1/cmake-3.1.3-Linux-x86_64.tar.gz
-      && tar zxf cmake-3.1.3-Linux-x86_64.tar.gz
-      && sudo cp -fR cmake-3.1.3-Linux-x86_64/* /usr/
   - wget https://googletest.googlecode.com/files/gtest-1.7.0.zip
       && cd test
       && unzip ../gtest-1.7.0.zip

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,7 @@
-CMAKE_MINIMUM_REQUIRED(VERSION 3.1)
+CMAKE_MINIMUM_REQUIRED(VERSION 2.8)
 PROJECT(libgraphqlparser C CXX)
+
+SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=gnu++11")
 
 FIND_PACKAGE(PythonInterp)
 IF (NOT PYTHON_VERSION_MAJOR EQUAL 2)
@@ -43,7 +45,10 @@ ADD_LIBRARY(graphqlparser SHARED
   lexer.h
   GraphQLParser.cpp)
 
-TARGET_COMPILE_FEATURES(graphqlparser PUBLIC cxx_auto_type cxx_override)
+# Enable this and remove CMAKE_CXX_FLAGS fiddle above when we are able
+# to upgrade to CMake 2.8.12. Blocker seems to be Travis CI being on
+# Ubuntu Precise; Trusty has 2.8.12.
+# TARGET_COMPILE_OPTIONS(graphqlparser PUBLIC -std=gnu++11)
 
 ADD_EXECUTABLE(dump_json_ast dump_json_ast.cpp)
 TARGET_LINK_LIBRARIES(dump_json_ast graphqlparser)


### PR DESCRIPTION
Looks like we only used 3.1 for -std=gnu++11. Manually specify that
instead. This should fix #3.