### PR TITLE
Fix the case of a gitignore stanza

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,7 @@ Ast.h
 Ast.cpp
 AstVisitor.h
 *.dSYM
-CmakeCache.txt
+CMakeCache.txt
 CMakeFiles
 CMakeScripts
 Makefile


### PR DESCRIPTION
Does what it says on the tin. On case-sensitive file-systems this was not catching the appropriate file.