### PR TITLE
Add install_manifest.txt to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ cmake_install.cmake
 *.dylib
 *.so
 GraphQLParser.py
+install_manifest.txt


### PR DESCRIPTION
install_manifest.txt gets created when running make install and it
should be ignored by the vcs