### PR TITLE
Test memory leaks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ cmake_install.cmake
 *.so
 GraphQLParser.py
 install_manifest.txt
+build/

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,4 +19,4 @@ before_install:
       && cd ..
       && rm gtest-1.7.0.zip
 
-script: mkdir build && cd build && cmake .. -Dtest=ON && make && test/runTests
+script: mkdir build && cd build && cmake .. -Dtest=ON && make && test/runTests && make memcheck

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,12 @@ compiler:
   - clang
   - gcc
 
+
+addons:
+  apt:
+    packages:
+      - valgrind
+
 before_install:
   - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
   - sudo apt-get update -qq

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,4 +99,12 @@ INSTALL(TARGETS graphqlparser
 
 IF (test)
   ADD_SUBDIRECTORY(test)
+
+  if(UNIX)
+    # setup valgrind
+    ADD_CUSTOM_TARGET(memcheck
+      valgrind --leak-check=full --dsymutil=yes --error-exitcode=1 ./test/runTests  >/dev/null
+    )
+  endif()
+
 ENDIF()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,7 +103,7 @@ IF (test)
   if(UNIX)
     # setup valgrind
     ADD_CUSTOM_TARGET(memcheck
-      valgrind --leak-check=full --dsymutil=yes --error-exitcode=1 ./test/runTests  >/dev/null
+      valgrind --leak-check=full --suppressions=./test/valgrind.supp --dsymutil=yes --error-exitcode=1 ./test/runTests  >/dev/null
     )
   endif()
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -4,6 +4,8 @@ ENABLE_TESTING()
 
 INCLUDE_DIRECTORIES(${gtest_SOURCE_DIR}/include ${gtest_SOURCE_DIR})
 
+FILE(COPY valgrind.supp DESTINATION .)
+
 ADD_EXECUTABLE(runTests ParserTests.cpp)
 
 TARGET_LINK_LIBRARIES(runTests gtest gtest_main)

--- a/test/valgrind.supp
+++ b/test/valgrind.supp
@@ -1,0 +1,33 @@
+{
+   <osx_strdup_query_string>
+   Memcheck:Cond
+   fun:strlen
+   fun:strdup
+   fun:_ZN2yy17GraphQLParserImpl5parseEv
+   fun:_ZN8facebook7graphqlL7doParseEPPKcPv
+   fun:_ZN8facebook7graphql11parseStringEPKcPS2_
+   fun:_ZL11expectErrorPKcS0_
+   fun:_ZN44ParserTests_TracksLocationAcrossStrings_Test8TestBodyEv
+   fun:_ZN7testing8internal38HandleSehExceptionsInMethodIfSupportedINS_4TestEvEET0_PT_MS4_FS3_vEPKc
+   fun:_ZN7testing8internal35HandleExceptionsInMethodIfSupportedINS_4TestEvEET0_PT_MS4_FS3_vEPKc
+   fun:_ZN7testing4Test3RunEv
+   fun:_ZN7testing8TestInfo3RunEv
+   fun:_ZN7testing8TestCase3RunEv
+}
+
+{
+   <unix_strdup_query_string>
+   Memcheck:Cond
+   fun:__GI_strlen
+   fun:strdup
+   fun:_ZN2yy17GraphQLParserImpl5parseEv
+   fun:_ZN8facebook7graphqlL7doParseEPPKcPv
+   fun:_ZN8facebook7graphql11parseStringEPKcPS2_
+   fun:_ZL11expectErrorPKcS0_
+   fun:_ZN44ParserTests_TracksLocationAcrossStrings_Test8TestBodyEv
+   fun:_ZN7testing8internal38HandleSehExceptionsInMethodIfSupportedINS_4TestEvEET0_PT_MS4_FS3_vEPKc
+   fun:_ZN7testing8internal35HandleExceptionsInMethodIfSupportedINS_4TestEvEET0_PT_MS4_FS3_vEPKc
+   fun:_ZN7testing4Test3RunEv
+   fun:_ZN7testing8TestInfo3RunEv
+   fun:_ZN7testing8TestCase3RunEv
+}


### PR DESCRIPTION
This is a [libcmark](https://github.com/jgm/cmark) trick I picked up recently. We can build a test that runs Valgrind over the entire test suite. 

In the best case scenario, Valgrind should return an exit status of 0. Otherwise, there's a memory leak somewhere that needs to be plugged.