### PR TITLE
Adding pkg-config generation to CMakeLists

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ cmake_install.cmake
 GraphQLParser.py
 install_manifest.txt
 build/
+libgraphqlparser.pc

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,10 @@
 CMAKE_MINIMUM_REQUIRED(VERSION 2.8)
 PROJECT(libgraphqlparser C CXX)
 
+SET(CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake" "${CMAKE_MODULE_PATH}")
+
+INCLUDE(version)
+
 SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=gnu++11")
 
 FIND_PACKAGE(PythonInterp 2 REQUIRED)
@@ -96,6 +100,17 @@ INSTALL(FILES
   DESTINATION include/graphqlparser)
 INSTALL(TARGETS graphqlparser
   LIBRARY DESTINATION lib)
+
+if (UNIX)
+  # generate pkgconfig file
+  include(FindPkgConfig QUIET)
+  if(PKG_CONFIG_FOUND)
+    # generate .pc and install
+    configure_file("libgraphqlparser.pc.in" "libgraphqlparser.pc" @ONLY)
+    install(FILES       "${CMAKE_CURRENT_BINARY_DIR}/libgraphqlparser.pc"
+            DESTINATION "${CMAKE_INSTALL_PREFIX}/lib/pkgconfig")
+  endif()
+endif()
 
 IF (test)
   ADD_SUBDIRECTORY(test)

--- a/cmake/version.cmake
+++ b/cmake/version.cmake
@@ -1,0 +1,14 @@
+find_package(Git QUIET)
+
+# default version string
+set(LIBGRAPHQLPARSER_VERSION "0.0-dev")
+
+if(GIT_EXECUTABLE AND EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/.git)
+  execute_process(COMMAND ${GIT_EXECUTABLE} describe --tags
+                  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+                  OUTPUT_VARIABLE LIBGRAPHQLPARSER_VERSION
+                  ERROR_QUIET
+                  OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+  string(SUBSTRING ${LIBGRAPHQLPARSER_VERSION} 1 -1 LIBGRAPHQLPARSER_VERSION)
+endif()

--- a/go/README.md
+++ b/go/README.md
@@ -1,9 +1,20 @@
-This directory contains an example usage of the GraphQL parser and AST
-library from Go. See [cgo's
-documentation](https://github.com/golang/go/wiki/cgo), particularly
-the "Function pointer callbacks" section, for explanation of the
-mechanisms in use.
+# About
+This directory contains an example using the libgraphqlparser C library from [Go](https://golang.org/project/).
 
-To build, first build the main GraphQLParser library in the parent
-directory, and then set this directory to be your `GOPATH` and run `go
-build`.
+For an overview of binding to C libraries in Go, please see the [cgo documentation](https://github.com/golang/go/wiki/cgo).
+Specifically, please read the overview of [Function pointer callbacks](https://github.com/golang/go/wiki/cgo#function-pointer-callbacks) in Go and C.
+
+## Building and Running
+
+To build with Go, please ensure that you have `pkg-config` installed for your
+system.
+
+Assuming pkg-config has been installed, it should be possible to then build
+using Go in the normal fashion:
+```sh
+$ cd libgraphqlparser/go
+$ go build
+$ ./go
+field : myfield
+Example error: 1.18-19: syntax error, unexpected on, expecting ( or @ or {
+```

--- a/go/gotest.go
+++ b/go/gotest.go
@@ -9,12 +9,12 @@
 package main
 
 /*
-#cgo CFLAGS: -I ../c -I ..
-#cgo LDFLAGS: -L .. -lgraphqlparser
-#include "GraphQLAst.h"
-#include "GraphQLAstNode.h"
-#include "GraphQLAstVisitor.h"
-#include "GraphQLParser.h"
+#cgo pkg-config: libgraphqlparser
+
+#include "c/GraphQLAst.h"
+#include "c/GraphQLAstNode.h"
+#include "c/GraphQLAstVisitor.h"
+#include "c/GraphQLParser.h"
 #include <stdlib.h>
 
 int printField_cgo(struct GraphQLAstField *field, void *unused);

--- a/libgraphqlparser.pc.in
+++ b/libgraphqlparser.pc.in
@@ -1,0 +1,11 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=${prefix}
+libdir=${exec_prefix}/lib
+includedir=${prefix}/include/graphqlparser
+
+Name: @CMAKE_PROJECT_NAME@
+Description: facebook graphql parsing library
+Version: @LIBGRAPHQLPARSER_VERSION@
+Libs: -L${libdir} -lgraphqlparser
+Libs.private:
+Cflags: -I${includedir} 


### PR DESCRIPTION
Adding the necessary magic to the CMakeLists.txt, including a new
version.cmake file that generates the pkg-config .pc file.

This file makes it much easier when building other applications/libraries
dependent on the installed package.

As an example, the short go version has also been updated to demonstrate
how compilers understanding pkg-config would make use of this file.