### PR TITLE
Fix bug in unescaping unicode escaped characters

### DIFF
--- a/lexer.cpp
+++ b/lexer.cpp
@@ -978,7 +978,7 @@ YY_RULE_SETUP
 #line 87 "lexer.lpp"
 {
     int ch;
-    sscanf(yytext + 1, "%x", &ch);
+    sscanf(yytext + 2, "%x", &ch);
     yyextra->str.push_back(ch);
   }
 	YY_BREAK

--- a/lexer.lpp
+++ b/lexer.lpp
@@ -86,7 +86,7 @@ notnewline [^\n\r]
 
   \\u[0-9A-Fa-f]{4} {
     int ch;
-    sscanf(yytext + 1, "%x", &ch);
+    sscanf(yytext + 2, "%x", &ch);
     yyextra->str.push_back(ch);
   }
 


### PR DESCRIPTION
## Problem

When a string literal has a unicode character escape (e.g. `\u0009`) then the parsed string was getting null terminated at that escape rather than having the unescaped character.

I tracked down the issue to the `sscanf(yytext + 1, "%x", &ch)` call in the lexer which was skipping over only the `\` and then trying to scan the `u` as a hexadecimal number.

## Solution

Start the scan from `yytext + 2` to skip over `\u` and scan the hex number.