### PR TITLE
Contributing graphql foundation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,9 +22,8 @@ Complete your CLA here: <https://code.facebook.com/cla>
 We use GitHub issues to track public bugs. Please ensure your description is
 clear and has sufficient instructions to be able to reproduce the issue.
 
-Facebook has a [bounty program](https://www.facebook.com/whitehat/) for the safe
-disclosure of security bugs. In those cases, please go through the process
-outlined on that page and do not file a public issue.
+If you find a security bug, please contact the project administrators,
+and do not file a public issue.
 
 ## License
 By contributing to libgraphqlparser, you agree that your contributions


### PR DESCRIPTION
This PR has two changes to the libgraphqlparser CONTRIBUTING.md to clean up after
the move of the repo from Facebook to the GraphQL foundation.

One more reference to the contribution being to Facebook and not to the GraphQL
Foundation is still present in the CLA.

This PR already updates the license to point to the already-updated LICENSE and already
updates the security bug procedure to be reporting bugs to the project maintainers.

We are submitting this PR to start discussion about these two changes and also
the CLA.