### PR TITLE
Update ruby reference link

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,4 +81,4 @@ libgraphqlparser is MIT-licensed.
 - [graphql_parser (Elixir interface)](https://github.com/aarvay/graphql_parser)
 - [graphql-parser-php (PHP interface)](https://github.com/dosten/graphql-parser-php)
 - [graphql-libgraphqlparser (Ruby interface)](https://github.com/rmosolgo/graphql-libgraphqlparser-ruby)
-- [graphql-ruby-client (Ruby interface)](https://github.com/Shopify/graphql-ruby-client)
+- [graphql-ruby (Ruby interface)](https://github.com/Shopify/graphql-ruby)

--- a/README.md
+++ b/README.md
@@ -77,8 +77,8 @@ libgraphqlparser is MIT-licensed.
 
 ## Related Projects
 
-- [graphql-parser (Ruby interface)](https://github.com/Shopify/graphql-parser)
 - [py-graphqlparser (Python interface)](https://github.com/elastic-coders/py-graphqlparser)
 - [graphql_parser (Elixir interface)](https://github.com/aarvay/graphql_parser)
 - [graphql-parser-php (PHP interface)](https://github.com/dosten/graphql-parser-php)
 - [graphql-libgraphqlparser (Ruby interface)](https://github.com/rmosolgo/graphql-libgraphqlparser-ruby)
+- [graphql-ruby-client (Ruby interface)](https://github.com/Shopify/graphql-ruby-client)


### PR DESCRIPTION
Shopify have either removed or made their repo private. The Ruby Parser isn't available. There is an interesting graphql-ruby gem. It was quite noticeable being the first link in the references 