### PR TITLE
Remove invalid bison version requirement

### DIFF
--- a/parser.ypp
+++ b/parser.ypp
@@ -5,8 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-%require "3"
-
 %skeleton "lalr1.cc"
 
 %defines


### PR DESCRIPTION
This is to get rid of this error:

    parser.ypp:8.10-12: error: invalid version requirement: 3
        8 | %require "3"
          |          ^~~