### PR TITLE
Added position.hh to installed files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,7 @@ ELSE()
     ${CMAKE_CURRENT_SOURCE_DIR}/parsergen/stack.hh
     ${CMAKE_CURRENT_BINARY_DIR})
 ENDIF()
+SET(BISON_POSITION_HEADER ${CMAKE_CURRENT_BINARY_DIR}/position.hh)
 
 IF(FLEX_FOUND)
   FLEX_TARGET(GraphQLScanner lexer.lpp ${CMAKE_CURRENT_BINARY_DIR}/lexer.cpp COMPILE_FLAGS "--header-file=${CMAKE_CURRENT_BINARY_DIR}/lexer.h")
@@ -120,6 +121,7 @@ INSTALL(FILES
   GraphQLParser.h
   JsonVisitor.h
   ${BISON_LOCATION_HEADER}
+  ${BISON_POSITION_HEADER}
   DESTINATION include/graphqlparser)
 INSTALL(TARGETS graphqlparser
   LIBRARY DESTINATION lib)


### PR DESCRIPTION
Currently `make install` doesn't install position.hh. This leads to code that uses this library failing to build. This PR fixes that by adding position.hh to the install.