### PR TITLE
Add EasyCLA info

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,3 +82,13 @@ libgraphqlparser is MIT-licensed.
 - [graphql_parser (Elixir interface)](https://github.com/aarvay/graphql_parser)
 - [graphql-parser-php (PHP interface)](https://github.com/dosten/graphql-parser-php)
 - [graphql-libgraphqlparser (Ruby interface)](https://github.com/rmosolgo/graphql-libgraphqlparser-ruby)
+
+## Contributing to this repo
+
+This repository is managed by EasyCLA. Project participants must sign the free ([GraphQL Specification Membership agreement](https://preview-spec-membership.graphql.org) before making a contribution. You only need to do this one time, and it can be signed by [individual contributors](http://individual-spec-membership.graphql.org/) or their [employers](http://corporate-spec-membership.graphql.org/).
+
+To initiate the signature process please open a PR against this repo. The EasyCLA bot will block the merge if we still need a membership agreement from you.
+
+You can find [detailed information here](https://github.com/graphql/graphql-wg/tree/main/membership). If you have issues, please email [operations@graphql.org](mailto:operations@graphql.org).
+
+If your company benefits from GraphQL and you would like to provide essential financial support for the systems and people that power our community, please also consider membership in the [GraphQL Foundation](https://foundation.graphql.org/join).


### PR DESCRIPTION
This is a trivial PR that adds EasyCLA information, along with instructions on how to sign the GraphQL Spec membership agreement. I'll merge it directly.

Signed-off-by: Brian Warner <brian@bdwarner.com>