### PR TITLE
fix go build command line

### DIFF
--- a/go/README.md
+++ b/go/README.md
@@ -13,7 +13,7 @@ Assuming pkg-config has been installed, it should be possible to then build
 using Go in the normal fashion:
 ```sh
 $ cd libgraphqlparser/go
-$ go build
+$ GO111MODULE="off" go build
 $ ./go
 field : myfield
 Example error: 1.18-19: syntax error, unexpected on, expecting ( or @ or {


### PR DESCRIPTION
```
vagrant@dev:/vagrant/libgraphqlparser/go$  go build
go: cannot find main module, but found .git/config in /vagrant/libgraphqlparser
        to create a module there, run:
        cd .. && go mod init
vagrant@dev:/vagrant/libgraphqlparser/go$ GO111MODULE="off" go build
vagrant@dev:/vagrant/libgraphqlparser/go$ ./go
field : myfield
Example error: 1.18-19: syntax error, unexpected on, expecting ( or @ or {
```