### PR TITLE
Require bison 3.2 and remove deprecated position.hh includes

### DIFF
--- a/JsonVisitor.cpp
+++ b/JsonVisitor.cpp
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#include "position.hh"
 #include "JsonVisitor.h"
 
 #include <cassert>

--- a/lexer.lpp
+++ b/lexer.lpp
@@ -14,7 +14,6 @@
 #include <string>
 #include <vector>
 #include "location.hh"
-#include "position.hh"
 #include "parser.tab.hpp"
 #include "syntaxdefs.h"
 

--- a/parser.ypp
+++ b/parser.ypp
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-%require "3"
+%require "3.2"
 
 %skeleton "lalr1.cc"
 


### PR DESCRIPTION
As of bison 3.2 ([released in 2018](https://ftp.gnu.org/gnu/bison/))

```
*** C++: stack.hh and position.hh are deprecated

  When asked to generate a header file (%defines), the lalr1.cc skeleton
  generates a stack.hh file.  This file had no interest for users; it is now
  made useless: its content is included in the parser definition.  It is
  still generated for backward compatibility.
```

This PR updates the code and handles this deprecation.